### PR TITLE
Multi Fallback Failure Listener

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ sudo: false
 android:
   components:
     - tools
-    - build-tools-23.0.2
-    - android-23
+    - build-tools-24.0.2
+    - android-24
     - extra-android-m2repository
     - extra-google-m2repository
     - extra-google-google_play_services

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ SmartLocation.with(context).location(new LocationBasedOnActivityProvider(callbac
 
 The `MultiFallbackProvider` lets you create your own provider that utilizes multiple underlying location services.
 The provider will use the location services in the order in which they are added to its `Builder`, which has convenience methods for setting up the Google Play Services provider and the default `LocationManager` provider.
+Providers must implement the `ServiceLocationProvider` interface to enable the fallback behavior.
 Example:
 
 ````java

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -66,6 +66,10 @@ def isReleaseBuild() {
     return version.contains("SNAPSHOT") == false
 }
 
+def getProperty(project, property) {
+    return project.hasProperty(property) ? project.property(property) : ""
+}
+
 signing {
     required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
@@ -76,13 +80,13 @@ uploadArchives {
     repositories.mavenDeployer {
         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-        repository(url: sonatypeRepo) {
-            authentication(userName: sonatypeUsername,
-                    password: sonatypePassword)
+        repository(url: getProperty(project, "sonatypeRepo")) {
+            authentication(userName: getProperty(project, "sonatypeUsername"),
+                    password: getProperty(project, "sonatypePassword"))
         }
-        snapshotRepository(url: sonatypeSnapshotRepo) {
-            authentication(userName: sonatypeUsername,
-                    password: sonatypePassword)
+        snapshotRepository(url: getProperty(project, "sonatypeSnapshotRepo")) {
+            authentication(userName: getProperty(project, "sonatypeUsername"),
+                    password: getProperty(project, "sonatypePassword"))
         }
 
         pom.project {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.1'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,9 +2,6 @@ buildscript {
     repositories {
         mavenCentral()
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
-    }
 }
 
 apply plugin: 'com.android.library'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
     }
 }
 
@@ -21,9 +21,8 @@ dependencies {
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
-    compile 'com.google.android.gms:play-services-location:9.4.0'
-    compile 'com.android.support:support-annotations:23.4.0'
-
+    compile 'com.google.android.gms:play-services-location:9.6.1'
+    compile 'com.android.support:support-annotations:24.2.1'
     provided 'io.reactivex:rxjava:1.1.7'
     provided 'io.reactivex:rxandroid:1.2.0'
     testCompile 'junit:junit:4.12'
@@ -33,8 +32,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    compileSdkVersion 24
+    buildToolsVersion '24.0.2'
 
     buildTypes {
         defaultConfig {

--- a/library/src/main/java/io/nlopez/smartlocation/location/ServiceLocationProvider.java
+++ b/library/src/main/java/io/nlopez/smartlocation/location/ServiceLocationProvider.java
@@ -1,0 +1,12 @@
+package io.nlopez.smartlocation.location;
+
+import io.nlopez.smartlocation.utils.ServiceConnectionListener;
+
+/**
+ * Created by findyr-akaplan on 5/12/16.
+ */
+public interface ServiceLocationProvider extends LocationProvider {
+
+    ServiceConnectionListener getServiceListener();
+    void setServiceListener(ServiceConnectionListener listener);
+}

--- a/library/src/main/java/io/nlopez/smartlocation/location/ServiceLocationProvider.java
+++ b/library/src/main/java/io/nlopez/smartlocation/location/ServiceLocationProvider.java
@@ -3,10 +3,24 @@ package io.nlopez.smartlocation.location;
 import io.nlopez.smartlocation.utils.ServiceConnectionListener;
 
 /**
- * Created by findyr-akaplan on 5/12/16.
+ * An extension of the {@link LocationProvider} interface for location providers that utilize 3rd
+ * party services. Implementations must invoke the appropriate {@link ServiceConnectionListener}
+ * events when the connection to the 3rd party service succeeds, fails, or is suspended.
+ *
+ * @author abkaplan07
  */
 public interface ServiceLocationProvider extends LocationProvider {
 
+    /**
+     * Gets the {@link ServiceConnectionListener} callback for this location provider.
+     */
     ServiceConnectionListener getServiceListener();
+
+    /**
+     * Set the {@link ServiceConnectionListener} used for callbacks from the 3rd party service.
+     *
+     * @param listener a <code>ServiceConnectionListener</code> to respond to connection events from
+     *                 the underlying 3rd party location service.
+     */
     void setServiceListener(ServiceConnectionListener listener);
 }

--- a/library/src/main/java/io/nlopez/smartlocation/location/providers/FallbackListenerWrapper.java
+++ b/library/src/main/java/io/nlopez/smartlocation/location/providers/FallbackListenerWrapper.java
@@ -1,0 +1,55 @@
+package io.nlopez.smartlocation.location.providers;
+
+import android.support.annotation.NonNull;
+
+import io.nlopez.smartlocation.location.LocationProvider;
+import io.nlopez.smartlocation.location.ServiceLocationProvider;
+import io.nlopez.smartlocation.utils.ServiceConnectionListener;
+
+/**
+ * Created by findyr-akaplan on 5/12/16.
+ */
+class FallbackListenerWrapper implements ServiceConnectionListener {
+
+    private final ServiceConnectionListener listener;
+    private final MultiFallbackProvider fallbackProvider;
+    private final ServiceLocationProvider childProvider;
+
+
+    public FallbackListenerWrapper(@NonNull MultiFallbackProvider parentProvider, ServiceLocationProvider childProvider) {
+        this.fallbackProvider = parentProvider;
+        this.childProvider = childProvider;
+        this.listener = childProvider.getServiceListener();
+    }
+
+    @Override
+    public void onConnected() {
+        if (listener != null) {
+            listener.onConnected();
+        }
+    }
+
+    @Override
+    public void onConnectionSuspended() {
+        if (listener != null) {
+            listener.onConnectionSuspended();
+        }
+        runFallback();
+
+    }
+
+    @Override
+    public void onConnectionFailed() {
+        if (listener != null) {
+            listener.onConnectionFailed();
+        }
+        runFallback();
+    }
+
+    private void runFallback() {
+        LocationProvider current = fallbackProvider.getCurrentProvider();
+        if (current != null && current.equals(childProvider)) {
+            fallbackProvider.fallbackProvider();
+        }
+    }
+}

--- a/library/src/main/java/io/nlopez/smartlocation/location/providers/FallbackListenerWrapper.java
+++ b/library/src/main/java/io/nlopez/smartlocation/location/providers/FallbackListenerWrapper.java
@@ -7,7 +7,10 @@ import io.nlopez.smartlocation.location.ServiceLocationProvider;
 import io.nlopez.smartlocation.utils.ServiceConnectionListener;
 
 /**
- * Created by findyr-akaplan on 5/12/16.
+ * A decorator for a {@link ServiceConnectionListener} used to execute the {@link
+ * MultiFallbackProvider}'s failover.
+ *
+ * @author abkaplan07
  */
 class FallbackListenerWrapper implements ServiceConnectionListener {
 
@@ -16,7 +19,8 @@ class FallbackListenerWrapper implements ServiceConnectionListener {
     private final ServiceLocationProvider childProvider;
 
 
-    public FallbackListenerWrapper(@NonNull MultiFallbackProvider parentProvider, ServiceLocationProvider childProvider) {
+    public FallbackListenerWrapper(@NonNull MultiFallbackProvider parentProvider,
+                                   ServiceLocationProvider childProvider) {
         this.fallbackProvider = parentProvider;
         this.childProvider = childProvider;
         this.listener = childProvider.getServiceListener();

--- a/library/src/main/java/io/nlopez/smartlocation/location/providers/LocationGooglePlayServicesProvider.java
+++ b/library/src/main/java/io/nlopez/smartlocation/location/providers/LocationGooglePlayServicesProvider.java
@@ -19,16 +19,17 @@ import com.google.android.gms.location.LocationSettingsResult;
 import com.google.android.gms.location.LocationSettingsStatusCodes;
 
 import io.nlopez.smartlocation.OnLocationUpdatedListener;
-import io.nlopez.smartlocation.location.LocationProvider;
 import io.nlopez.smartlocation.location.LocationStore;
+import io.nlopez.smartlocation.location.ServiceLocationProvider;
 import io.nlopez.smartlocation.location.config.LocationParams;
 import io.nlopez.smartlocation.utils.GooglePlayServicesListener;
 import io.nlopez.smartlocation.utils.Logger;
+import io.nlopez.smartlocation.utils.ServiceConnectionListener;
 
 /**
  * Created by mrm on 20/12/14.
  */
-public class LocationGooglePlayServicesProvider implements LocationProvider, GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener, LocationListener, ResultCallback<Status> {
+public class LocationGooglePlayServicesProvider implements ServiceLocationProvider, GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener, LocationListener, ResultCallback<Status> {
 
     public static final int REQUEST_START_LOCATION_FIX = 10001;
     public static final int REQUEST_CHECK_SETTINGS = 20001;
@@ -42,18 +43,24 @@ public class LocationGooglePlayServicesProvider implements LocationProvider, Goo
     private LocationStore locationStore;
     private LocationRequest locationRequest;
     private Context context;
-    private final GooglePlayServicesListener googlePlayServicesListener;
+    private GooglePlayServicesListener googlePlayServicesListener;
+    private ServiceConnectionListener serviceListener;
     private boolean checkLocationSettings;
     private boolean fulfilledCheckLocationSettings;
 
     public LocationGooglePlayServicesProvider() {
-        this(null);
+        checkLocationSettings =  false;
+        fulfilledCheckLocationSettings = false;
     }
 
     public LocationGooglePlayServicesProvider(GooglePlayServicesListener playServicesListener) {
+        this();
         googlePlayServicesListener = playServicesListener;
-        checkLocationSettings = false;
-        fulfilledCheckLocationSettings = false;
+    }
+
+    public LocationGooglePlayServicesProvider(ServiceConnectionListener serviceListener) {
+        this();
+        this.serviceListener = serviceListener;
     }
 
     @Override
@@ -170,6 +177,16 @@ public class LocationGooglePlayServicesProvider implements LocationProvider, Goo
     }
 
     @Override
+    public ServiceConnectionListener getServiceListener() {
+        return serviceListener;
+    }
+
+    @Override
+    public void setServiceListener(ServiceConnectionListener listener) {
+        serviceListener = listener;
+    }
+
+    @Override
     public void onConnected(Bundle bundle) {
         logger.d("onConnected");
         if (shouldStart) {
@@ -177,6 +194,9 @@ public class LocationGooglePlayServicesProvider implements LocationProvider, Goo
         }
         if (googlePlayServicesListener != null) {
             googlePlayServicesListener.onConnected(bundle);
+        }
+        if (serviceListener != null) {
+            serviceListener.onConnected();
         }
     }
 
@@ -186,6 +206,9 @@ public class LocationGooglePlayServicesProvider implements LocationProvider, Goo
         if (googlePlayServicesListener != null) {
             googlePlayServicesListener.onConnectionSuspended(i);
         }
+        if (serviceListener != null) {
+            serviceListener.onConnectionSuspended();
+        }
     }
 
     @Override
@@ -193,6 +216,9 @@ public class LocationGooglePlayServicesProvider implements LocationProvider, Goo
         logger.d("onConnectionFailed " + connectionResult.toString());
         if (googlePlayServicesListener != null) {
             googlePlayServicesListener.onConnectionFailed(connectionResult);
+        }
+        if (serviceListener != null) {
+            serviceListener.onConnectionFailed();
         }
     }
 

--- a/library/src/main/java/io/nlopez/smartlocation/location/providers/MultiFallbackProvider.java
+++ b/library/src/main/java/io/nlopez/smartlocation/location/providers/MultiFallbackProvider.java
@@ -1,10 +1,7 @@
 package io.nlopez.smartlocation.location.providers;
 
-import com.google.android.gms.common.ConnectionResult;
-
 import android.content.Context;
 import android.location.Location;
-import android.os.Bundle;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -12,8 +9,8 @@ import java.util.Queue;
 
 import io.nlopez.smartlocation.OnLocationUpdatedListener;
 import io.nlopez.smartlocation.location.LocationProvider;
+import io.nlopez.smartlocation.location.ServiceLocationProvider;
 import io.nlopez.smartlocation.location.config.LocationParams;
-import io.nlopez.smartlocation.utils.GooglePlayServicesListener;
 import io.nlopez.smartlocation.utils.Logger;
 
 /**
@@ -140,32 +137,7 @@ public class MultiFallbackProvider implements LocationProvider {
          * Adds Google Location Services as a provider.
          */
         public Builder withGooglePlayServicesProvider() {
-            GooglePlayServicesListener googleListener = new GooglePlayServicesListener() {
-                @Override
-                public void onConnected(Bundle bundle) {
-                    // noop
-                }
-
-                @Override
-                public void onConnectionSuspended(int i) {
-                    runFallback();
-                }
-
-                @Override
-                public void onConnectionFailed(ConnectionResult connectionResult) {
-                    runFallback();
-                }
-
-                private void runFallback() {
-                    LocationProvider current = builtProvider.getCurrentProvider();
-                    if (current != null && current instanceof LocationGooglePlayServicesProvider) {
-                        builtProvider.fallbackProvider();
-                    }
-                }
-            };
-            LocationGooglePlayServicesProvider googleProvider = new
-                    LocationGooglePlayServicesProvider(googleListener);
-            return withProvider(googleProvider);
+            return withServiceProvider(new LocationGooglePlayServicesProvider());
         }
 
         /**
@@ -176,7 +148,24 @@ public class MultiFallbackProvider implements LocationProvider {
         }
 
         /**
-         * Adds the given {@link LocationProvider} as a provider.
+         * Adds the given {@link ServiceLocationProvider} as a location provider. If the given
+         * location provider detects that its underlying service is not available, the built
+         * <code>MultiFallbackProvider</code> will fall back to the next location provider in the
+         * list.
+         *
+         * @param provider a <code>ServiceLocationProvider</code> that can detect if the underlying
+         *                 location service is not available.
+         */
+        public Builder withServiceProvider(ServiceLocationProvider provider) {
+            FallbackListenerWrapper fallbackListener = new FallbackListenerWrapper(builtProvider,
+                    provider);
+            provider.setServiceListener(fallbackListener);
+            return withProvider(provider);
+        }
+
+        /**
+         * Adds the given {@link LocationProvider} as a provider. Note that these providers
+         * <strong>DO NOT</strong> support fallback behavior.
          *
          * @param provider a <code>LocationProvider</code> instance.
          */

--- a/library/src/main/java/io/nlopez/smartlocation/location/providers/MultiFallbackProvider.java
+++ b/library/src/main/java/io/nlopez/smartlocation/location/providers/MultiFallbackProvider.java
@@ -114,6 +114,9 @@ public class MultiFallbackProvider implements LocationProvider {
      */
     void fallbackProvider() {
         if (!providers.isEmpty()) {
+            // Stop the current provider if it is running
+            currentProvider.stop();
+            // Fetch the next provider in the list.
             currentProvider = providers.poll();
             currentProvider.init(context, logger);
             if (shouldStart) {

--- a/library/src/main/java/io/nlopez/smartlocation/utils/ServiceConnectionListener.java
+++ b/library/src/main/java/io/nlopez/smartlocation/utils/ServiceConnectionListener.java
@@ -1,0 +1,13 @@
+package io.nlopez.smartlocation.utils;
+
+/**
+ * Created by findyr-akaplan on 5/12/16.
+ */
+public interface ServiceConnectionListener {
+
+    void onConnected();
+
+    void onConnectionSuspended();
+
+    void onConnectionFailed();
+}

--- a/library/src/main/java/io/nlopez/smartlocation/utils/ServiceConnectionListener.java
+++ b/library/src/main/java/io/nlopez/smartlocation/utils/ServiceConnectionListener.java
@@ -1,13 +1,26 @@
 package io.nlopez.smartlocation.utils;
 
 /**
- * Created by findyr-akaplan on 5/12/16.
+ * A callback interface to respond to connection events from 3rd party services.
+ *
+ * @author abkaplan07
  */
 public interface ServiceConnectionListener {
 
+    /**
+     * Callback when a successful connection to a 3rd party service is made
+     */
     void onConnected();
 
+    /**
+     * Callback when the connection to a 3rd party service is interrupted (network failure,
+     * temporary outage, etc.)
+     */
     void onConnectionSuspended();
 
+    /**
+     * Callback when the connection to a 3rd party service fails (missing libraries, bad API key,
+     * etc.)
+     */
     void onConnectionFailed();
 }

--- a/library/src/test/java/io/nlopez/smartlocation/location/providers/MultiFallbackProviderTest.java
+++ b/library/src/test/java/io/nlopez/smartlocation/location/providers/MultiFallbackProviderTest.java
@@ -79,6 +79,7 @@ public class MultiFallbackProviderTest {
         testServiceProvider.simulateFailure();
         // Ensure that our 1st listener from the test service provider was invoked.
         verify(mockListener).onConnectionFailed();
+        assertEquals(1, testServiceProvider.getStopCount());
         // Verify that the backup provider is initialized and started.
         verify(backupProvider).init(any(Context.class), any(Logger.class));
         verify(backupProvider).start(listenerMock, paramsMock, false);
@@ -86,7 +87,7 @@ public class MultiFallbackProviderTest {
         // Test that we're now using the fallback provider to stop.
         subject.stop();
         verify(backupProvider).stop();
-        assertEquals(0, testServiceProvider.getStopCount());
+        assertEquals(1, testServiceProvider.getStopCount());
 
         // Test that we're now using the fallback provider to get the last location
         Location mockLocation = mock(Location.class);

--- a/library/src/test/java/io/nlopez/smartlocation/location/providers/MultiFallbackProviderTest.java
+++ b/library/src/test/java/io/nlopez/smartlocation/location/providers/MultiFallbackProviderTest.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for the {@link MultiFallbackProvider}
+ *
+ * @author abkaplan07
  */
 @RunWith(CustomTestRunner.class)
 @Config(manifest=Config.NONE)

--- a/library/src/test/java/io/nlopez/smartlocation/location/providers/TestServiceProvider.java
+++ b/library/src/test/java/io/nlopez/smartlocation/location/providers/TestServiceProvider.java
@@ -11,6 +11,8 @@ import io.nlopez.smartlocation.utils.ServiceConnectionListener;
 
 /**
  * Test double for a {@link ServiceLocationProvider}.
+ *
+ * @author abkaplan07
  */
 public class TestServiceProvider implements ServiceLocationProvider {
 

--- a/library/src/test/java/io/nlopez/smartlocation/location/providers/TestServiceProvider.java
+++ b/library/src/test/java/io/nlopez/smartlocation/location/providers/TestServiceProvider.java
@@ -1,0 +1,80 @@
+package io.nlopez.smartlocation.location.providers;
+
+import android.content.Context;
+import android.location.Location;
+
+import io.nlopez.smartlocation.OnLocationUpdatedListener;
+import io.nlopez.smartlocation.location.ServiceLocationProvider;
+import io.nlopez.smartlocation.location.config.LocationParams;
+import io.nlopez.smartlocation.utils.Logger;
+import io.nlopez.smartlocation.utils.ServiceConnectionListener;
+
+/**
+ * Test double for a {@link ServiceLocationProvider}.
+ */
+public class TestServiceProvider implements ServiceLocationProvider {
+
+    private ServiceConnectionListener listener;
+    private int initCount;
+    private int startCount;
+    private int stopCount;
+    private int lastLocCount;
+
+    @Override
+    public ServiceConnectionListener getServiceListener() {
+        return listener;
+    }
+
+    @Override
+    public void setServiceListener(ServiceConnectionListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void init(Context context, Logger logger) {
+        initCount++;
+    }
+
+    @Override
+    public void start(OnLocationUpdatedListener listener, LocationParams params, boolean
+            singleUpdate) {
+        startCount++;
+    }
+
+    @Override
+    public void stop() {
+        stopCount++;
+    }
+
+    @Override
+    public Location getLastLocation() {
+        lastLocCount++;
+        return null;
+    }
+
+    public int getInitCount() {
+        return initCount;
+    }
+
+    public int getStartCount() {
+        return startCount;
+    }
+
+    public int getStopCount() {
+        return stopCount;
+    }
+
+    public int getLastLocCount() {
+        return lastLocCount;
+    }
+
+    /**
+     * Simulate a service connection failure, and call
+     * {@link ServiceConnectionListener#onConnectionFailed()}
+     */
+    public void simulateFailure() {
+        if (listener != null) {
+            listener.onConnectionFailed();
+        }
+    }
+}


### PR DESCRIPTION
- Extended the `LocationProvider` interface to add support for listening to 3rd-party location service connections (`ServiceLocationProvider`).
- Enhanced `MultiFallbackProvider` so that it can listen for disconnects/drops from 3rd-party services, and execute fallback behavior.

Also fixed `library/build.gradle` so that Gradle can run without a `gradle.properties` file defined.
