### PR TITLE
Fix for broken requestLocationUpdates api call

### DIFF
--- a/library/src/main/java/io/nlopez/smartlocation/location/providers/LocationManagerProvider.java
+++ b/library/src/main/java/io/nlopez/smartlocation/location/providers/LocationManagerProvider.java
@@ -47,7 +47,7 @@ public class LocationManagerProvider implements LocationProvider, LocationListen
         if (singleUpdate) {
             locationManager.requestSingleUpdate(criteria, this, Looper.getMainLooper());
         } else {
-            locationManager.requestLocationUpdates(params.getInterval(), params.getDistance(), criteria, this, Looper.getMainLooper());
+            locationManager.requestLocationUpdates(locationManager.getBestProvider(criteria, true), 0, 0, this,  Looper.getMainLooper());
         }
     }
 


### PR DESCRIPTION
LocationManager requestLcoationUpdates() call is broken on some android phones (for example Xperia M4 Android 5.0) when used with Criteria argument. Location update never fire. See http://stackoverflow.com/questions/30118106/requestlocationupdates-with-criteria-doesnt-work