### PR TITLE
travis.yml changes to fix SDK license errors on travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+#bump
 language: android
 jdk: oraclejdk7
 sudo: false
@@ -16,3 +17,4 @@ android:
 script:
     - cp gradle.properties.example gradle.properties
     - ./gradlew clean assembleDebug testDebug
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-#bump
 language: android
 jdk: oraclejdk7
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ sudo: false
 android:
   components:
     - tools
-    - build-tools-23.0.2
-    - android-23
+    - platform-tools
+    - tools
+    - build-tools-25
+    - android-25
     - extra-android-m2repository
     - extra-google-m2repository
     - extra-google-google_play_services


### PR DESCRIPTION
This PR modifies the travis.yml by adding additional `android.components:` for SDK license errors reported in builds. 

 to install newer like `build-tools-25` and `android-25` on travis, proposed changes were needed at the top of  `android.components:` section.

NB: please note that `tools` is listed twice. My understanding is that the first `tools` gets an xml containing a repository address, the second uses this repo to install the newer components. Tested 3x per each commit. :ghost: :jack_o_lantern: 