### PR TITLE
fix no provider found exception

### DIFF
--- a/library/src/main/java/io/nlopez/smartlocation/location/providers/LocationManagerProvider.java
+++ b/library/src/main/java/io/nlopez/smartlocation/location/providers/LocationManagerProvider.java
@@ -62,8 +62,17 @@ public class LocationManagerProvider implements LocationProvider, LocationListen
             }
             locationManager.requestSingleUpdate(criteria, this, Looper.getMainLooper());
         } else {
+            String provider = locationManager.getBestProvider(criteria, true);
+            if (provider == null) {
+                logger.e("No provider found for criteria %s", criteria.toString());
+                return;
+            }
             locationManager.requestLocationUpdates(
-                    params.getInterval(), params.getDistance(), criteria, this, Looper.getMainLooper());
+                provider,
+                params.getInterval(),
+                params.getDistance(),
+                this,  Looper.getMainLooper()
+            );
         }
     }
 


### PR DESCRIPTION
Fatal Exception: 
java.lang.IllegalArgumentException: name==null
       at android.location.LocationManager.getProvider(LocationManager.java:335)
       at android.location.LocationManager._requestLocationUpdates(LocationManager.java:658)
       at android.location.LocationManager.requestLocationUpdates(LocationManager.java:645)
       at io.nlopez.smartlocation.location.providers.LocationManagerProvider.start(LocationManagerProvider.java:65)
       at io.nlopez.smartlocation.location.providers.LocationGooglePlayServicesWithFallbackProvider.fallbackToLocationManager(LocationGooglePlayServicesWithFallbackProvider.java:88)
       at io.nlopez.smartlocation.location.providers.LocationGooglePlayServicesWithFallbackProvider.onConnectionSuspended(LocationGooglePlayServicesWithFallbackProvider.java:75)
       at io.nlopez.smartlocation.location.providers.LocationGooglePlayServicesProvider.onConnectionSuspended(LocationGooglePlayServicesProvider.java:215)
       at com.google.android.gms.common.internal.zzm.zzcP(Unknown Source)