### PR TITLE
LocationGooglePlayServicesProvider compatible with Fragment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 29 12:50:39 CEST 2016
+#Wed Apr 19 23:57:00 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 apply plugin: 'maven'
 apply plugin: 'signing'
-
+apply plugin: 'com.github.dcendents.android-maven'
 
 version smartLocationVersion
 group 'io.nlopez.smartlocation'
@@ -18,8 +18,8 @@ dependencies {
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
-    compile 'com.google.android.gms:play-services-location:10.2.0'
-    compile 'com.android.support:support-annotations:25.2.0'
+    compile 'com.google.android.gms:play-services-location:10.2.1'
+    compile 'com.android.support:support-annotations:25.3.1'
     testCompile "junit:junit:$junitVersion"
     testCompile "org.robolectric:robolectric:$robolectricVersion"
     testCompile "org.robolectric:robolectric-shadows:$robolectricVersion"

--- a/library/src/main/java/io/nlopez/smartlocation/location/providers/LocationGooglePlayServicesProvider.java
+++ b/library/src/main/java/io/nlopez/smartlocation/location/providers/LocationGooglePlayServicesProvider.java
@@ -9,7 +9,9 @@ import android.content.pm.PackageManager;
 import android.location.Location;
 import android.os.Bundle;
 import android.os.Looper;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
+import android.support.v4.app.Fragment;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
@@ -52,9 +54,10 @@ public class LocationGooglePlayServicesProvider implements ServiceLocationProvid
     private boolean checkLocationSettings;
     private boolean fulfilledCheckLocationSettings;
     private boolean alwaysShow = true;
+    private Fragment mFragment;
 
     public LocationGooglePlayServicesProvider() {
-        checkLocationSettings =  false;
+        checkLocationSettings = false;
         fulfilledCheckLocationSettings = false;
     }
 
@@ -65,6 +68,21 @@ public class LocationGooglePlayServicesProvider implements ServiceLocationProvid
 
     public LocationGooglePlayServicesProvider(ServiceConnectionListener serviceListener) {
         this();
+        this.serviceListener = serviceListener;
+    }
+
+    public LocationGooglePlayServicesProvider(@NonNull Fragment fragment) {
+        this();
+        mFragment = fragment;
+    }
+
+    public LocationGooglePlayServicesProvider(@NonNull Fragment fragment, GooglePlayServicesListener playServicesListener) {
+        this(fragment);
+        googlePlayServicesListener = playServicesListener;
+    }
+
+    public LocationGooglePlayServicesProvider(@NonNull Fragment fragment, ServiceConnectionListener serviceListener) {
+        this(fragment);
         this.serviceListener = serviceListener;
     }
 
@@ -284,7 +302,8 @@ public class LocationGooglePlayServicesProvider implements ServiceLocationProvid
     }
 
     /**
-     * @return TRUE if active, FALSE if the settings wont be checked before launching the location updates request
+     * @return TRUE if active, FALSE if the settings wont be checked before launching the location
+     * updates request
      */
     public boolean isCheckingLocationSettings() {
         return checkLocationSettings;
@@ -304,7 +323,8 @@ public class LocationGooglePlayServicesProvider implements ServiceLocationProvid
     /**
      * Sets whether or not we should show location settings dialog with NEVER button
      *
-     * @param alwaysShow TRUE to show dialog without NEVER button, FALSE - with NEVER button (default)
+     * @param alwaysShow TRUE to show dialog without NEVER button, FALSE - with NEVER button
+     *                   (default)
      */
     public void setLocationSettingsAlwaysShow(boolean alwaysShow) {
         this.alwaysShow = alwaysShow;
@@ -313,10 +333,6 @@ public class LocationGooglePlayServicesProvider implements ServiceLocationProvid
     /**
      * This method should be called in the onActivityResult of the calling activity whenever we are
      * trying to implement the Check Location Settings fix dialog.
-     *
-     * @param requestCode
-     * @param resultCode
-     * @param data
      */
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == REQUEST_CHECK_SETTINGS) {
@@ -359,7 +375,13 @@ public class LocationGooglePlayServicesProvider implements ServiceLocationProvid
                     logger.w("Location settings are not satisfied. Show the user a dialog to " +
                             "upgrade location settings. You should hook into the Activity onActivityResult and call this provider's onActivityResult method for continuing this call flow. ");
 
-                    if (context instanceof Activity) {
+                    if (mFragment != null) {
+                        try {
+                            mFragment.startIntentSenderForResult(status.getResolution().getIntentSender(), REQUEST_CHECK_SETTINGS, null, 0, 0, 0, null);
+                        } catch (IntentSender.SendIntentException e) {
+                            logger.i("getIntentSender error unable to execute request.");
+                        }
+                    } else if (context instanceof Activity) {
                         try {
                             // Show the dialog by calling startResolutionForResult(), and check the result
                             // in onActivityResult().


### PR DESCRIPTION
Added the ability to start SmartLocation.location(locationGooglePlayServicesProvider).start() from a Fragment and get the onActivityResult(int requestCode, int resultCode, Intent data) on the fragment itself. 

Previously the activityResult was only called on the Activity.

LocationGooglePlayServicesWithFallbackProvider also modified to reflect this enhancement.

Updated Gradle android plugin to 2.3.1
Gradle updated to 3.3
Compatible with Jitpack.io
Google Play Services updated to 10.2.1
Android Support Annotations updated to 25.3.1